### PR TITLE
Fix test suite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM buildkite/plugin-tester
+
+RUN apk add --no-cache \
+  jq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 version: "3"
 services:
   tests:
-    image: "buildkite/plugin-tester"
+    build:
+      context: .
     volumes:
       - ".:/plugin"
   lint:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,6 @@ services:
       - ".:/plugin"
   lint:
     image: "buildkite/plugin-linter"
-    command: ["--id", "envato/bundle-update"]
+    command: ["--id", "envato/github-pull-request"]
     volumes:
       - ".:/plugin:ro"

--- a/lib/github.bash
+++ b/lib/github.bash
@@ -12,6 +12,7 @@ function open_pull_request() {
   local url
 
   payload=$(jq -n \
+               --compact-output \
                --arg TITLE "${title}" \
                --arg BODY  "${body}" \
                --arg HEAD  "${head}" \
@@ -30,6 +31,7 @@ function request_reviews() {
   local url
 
   payload=$(jq -n \
+               --compact-output \
                --arg REVIEWERS      "${reviewers}" \
                --arg TEAM_REVIEWERS "${team_reviewers}" \
                '{ reviewers: $REVIEWERS | split("\n"), team_reviewers: $TEAM_REVIEWERS | split("\n") }')
@@ -44,7 +46,7 @@ function add_labels() {
   local payload
   local url
 
-  payload=$(jq -n --arg LABELS "${labels}" '$LABELS | split("\n")')
+  payload=$(jq -n --compact-output --arg LABELS "${labels}" '$LABELS | split("\n")')
   url="$(base_url "${repo}")/issues/${pr_number}/labels"
   github_post add_labels "${url}" "${payload}"
 }

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -6,7 +6,6 @@ load "$BATS_PATH/load.bash"
 # export JQ_STUB_DEBUG=/dev/tty
 # export CURL_STUB_DEBUG=/dev/tty
 # export GIT_STUB_DEBUG=/dev/tty
-# export CAT_STUB_DEBUG=/dev/tty
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
 @test 'Opens the Github pull request' {
@@ -21,7 +20,6 @@ load "$BATS_PATH/load.bash"
     '.html_url : echo pr-url'
   stub curl '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200'
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
-  stub cat 'tmp/github_api_calls/open_pull_request_response.json : echo json-open-pr-response'
   stub buildkite-agent
 
   run $PWD/hooks/command
@@ -45,7 +43,6 @@ load "$BATS_PATH/load.bash"
     '.html_url : echo pr-url'
   stub curl '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200'
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
-  stub cat 'tmp/github_api_calls/open_pull_request_response.json : echo json-open-pr-response'
   stub buildkite-agent 'meta-data set github-pull-request-plugin-number 711 : echo metadata set'
 
   run $PWD/hooks/command
@@ -67,7 +64,6 @@ load "$BATS_PATH/load.bash"
     '.html_url : echo pr-url'
   stub curl '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/another-owner/another-project/pulls : echo 200'
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
-  stub cat 'tmp/github_api_calls/open_pull_request_response.json : echo json-open-pr-response'
   stub buildkite-agent
 
   run $PWD/hooks/command
@@ -93,7 +89,6 @@ load "$BATS_PATH/load.bash"
     '.html_url : echo pr-url'
   stub curl '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200'
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
-  stub cat 'tmp/github_api_calls/open_pull_request_response.json : echo json-open-pr-response'
   stub buildkite-agent
 
   run $PWD/hooks/command
@@ -121,9 +116,6 @@ load "$BATS_PATH/load.bash"
     '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200' \
     '--silent --write-out %{http_code} --data json-request-reviews-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/request_reviews_response.json --request POST https://api.github.com/repos/owner/project/pulls/711/requested_reviewers : echo 200'
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
-  stub cat \
-    'tmp/github_api_calls/open_pull_request_response.json : echo json-open-pr-response' \
-    'tmp/github_api_calls/request_reviews_response.json : echo json-request-reviews-response'
   stub buildkite-agent
 
   run $PWD/hooks/command
@@ -153,9 +145,6 @@ load "$BATS_PATH/load.bash"
     '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200' \
     '--silent --write-out %{http_code} --data json-request-reviews-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/request_reviews_response.json --request POST https://api.github.com/repos/owner/project/pulls/711/requested_reviewers : echo 200'
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
-  stub cat \
-    'tmp/github_api_calls/open_pull_request_response.json : echo json-open-pr-response' \
-    'tmp/github_api_calls/request_reviews_response.json : echo json-request-reviews-response'
   stub buildkite-agent
 
   run $PWD/hooks/command
@@ -184,9 +173,6 @@ load "$BATS_PATH/load.bash"
     '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200' \
     '--silent --write-out %{http_code} --data json-request-reviews-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/request_reviews_response.json --request POST https://api.github.com/repos/owner/project/pulls/711/requested_reviewers : echo 200'
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
-  stub cat \
-    'tmp/github_api_calls/open_pull_request_response.json : echo json-open-pr-response' \
-    'tmp/github_api_calls/request_reviews_response.json : echo json-request-reviews-response'
   stub buildkite-agent
 
   run $PWD/hooks/command
@@ -216,9 +202,6 @@ load "$BATS_PATH/load.bash"
     '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200' \
     '--silent --write-out %{http_code} --data json-request-reviews-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/request_reviews_response.json --request POST https://api.github.com/repos/owner/project/pulls/711/requested_reviewers : echo 200'
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
-  stub cat \
-    'tmp/github_api_calls/open_pull_request_response.json : echo json-open-pr-response' \
-    'tmp/github_api_calls/request_reviews_response.json : echo json-request-reviews-response'
   stub buildkite-agent
 
   run $PWD/hooks/command
@@ -247,9 +230,6 @@ load "$BATS_PATH/load.bash"
     '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200' \
     '--silent --write-out %{http_code} --data json-add-labels-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/add_labels_response.json --request POST https://api.github.com/repos/owner/project/issues/711/labels : echo 200'
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
-  stub cat \
-    'tmp/github_api_calls/open_pull_request_response.json : echo json-open-pr-response' \
-    'tmp/github_api_calls/add_labels_response.json : echo json-add-labels-response'
   stub buildkite-agent
 
   run $PWD/hooks/command
@@ -274,7 +254,6 @@ load "$BATS_PATH/load.bash"
     '.html_url : echo pr-url'
   stub curl '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 500'
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
-  stub cat 'tmp/github_api_calls/open_pull_request_response.json : echo json-open-pr-response'
   stub buildkite-agent
 
   run $PWD/hooks/command

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -13,14 +13,14 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_BODY=pr-body
   export GITHUB_TOKEN=secret-github-token
 
-  stub curl '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200'
+  stub curl "--silent --write-out '%{http_code}' --data '{\"title\":\"pr-title\",\"body\":\"pr-body\",\"head\":\"feature-branch\",\"base\":\"master\"}' --header 'Authorization: Bearer secret-github-token' --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo '{\"number\":42,\"html_url\":\"https://github.com/owner/project/pull/42\"}' > tmp/github_api_calls/open_pull_request_response.json && echo 200"
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
   stub buildkite-agent
 
   run $PWD/hooks/command
 
   assert_success
-  assert_output --partial 'Github pull request opened: pr-url'
+  assert_output --partial 'Github pull request opened: "https://github.com/owner/project/pull/42"'
   unstub curl
   unstub git
 }
@@ -31,14 +31,15 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_BODY=pr-body
   export GITHUB_TOKEN=secret-github-token
 
-  stub curl '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200'
+  stub curl "--silent --write-out '%{http_code}' --data '{\"title\":\"pr-title\",\"body\":\"pr-body\",\"head\":\"feature-branch\",\"base\":\"master\"}' --header 'Authorization: Bearer secret-github-token' --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo '{\"number\":42,\"html_url\":\"https://github.com/owner/project/pull/42\"}' > tmp/github_api_calls/open_pull_request_response.json && echo 200"
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
-  stub buildkite-agent 'meta-data set github-pull-request-plugin-number 711 : echo metadata set'
+  stub buildkite-agent 'meta-data set github-pull-request-plugin-number 42 : echo metadata set'
 
   run $PWD/hooks/command
 
   assert_success
   unstub buildkite-agent
+  unstub git
 }
 
 @test 'Opens the Github pull request on specified repository' {
@@ -48,14 +49,14 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_REPO=another-owner/another-project
   export GITHUB_TOKEN=secret-github-token
 
-  stub curl '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/another-owner/another-project/pulls : echo 200'
+  stub curl "--silent --write-out '%{http_code}' --data '{\"title\":\"pr-title\",\"body\":\"pr-body\",\"head\":\"feature-branch\",\"base\":\"master\"}' --header 'Authorization: Bearer secret-github-token' --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/another-owner/another-project/pulls : echo '{\"number\":42,\"html_url\":\"https://github.com/another-owner/another-project/pull/42\"}' > tmp/github_api_calls/open_pull_request_response.json && echo 200"
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
   stub buildkite-agent
 
   run $PWD/hooks/command
 
   assert_success
-  assert_output --partial 'Github pull request opened: pr-url'
+  assert_output --partial 'Github pull request opened: "https://github.com/another-owner/another-project/pull/42"'
   unstub curl
   unstub git
 }
@@ -68,14 +69,14 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_BASE=pr-base
   export GITHUB_TOKEN=secret-github-token
 
-  stub curl '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200'
+  stub curl "--silent --write-out '%{http_code}' --data '{\"title\":\"pr-title\",\"body\":\"pr-body\",\"head\":\"pr-head\",\"base\":\"pr-base\"}' --header 'Authorization: Bearer secret-github-token' --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo '{\"number\":42,\"html_url\":\"https://github.com/owner/project/pull/42\"}' > tmp/github_api_calls/open_pull_request_response.json && echo 200"
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
   stub buildkite-agent
 
   run $PWD/hooks/command
 
   assert_success
-  assert_output --partial 'Github pull request opened: pr-url'
+  assert_output --partial 'Github pull request opened: "https://github.com/owner/project/pull/42"'
   unstub curl
   unstub git
 }
@@ -88,15 +89,15 @@ load "$BATS_PATH/load.bash"
   export GITHUB_TOKEN=secret-github-token
 
   stub curl \
-    '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200' \
-    '--silent --write-out %{http_code} --data json-request-reviews-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/request_reviews_response.json --request POST https://api.github.com/repos/owner/project/pulls/711/requested_reviewers : echo 200'
+    "--silent --write-out '%{http_code}' --data '{\"title\":\"pr-title\",\"body\":\"pr-body\",\"head\":\"feature-branch\",\"base\":\"master\"}' --header 'Authorization: Bearer secret-github-token' --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo '{\"number\":42,\"html_url\":\"https://github.com/owner/project/pull/42\"}' > tmp/github_api_calls/open_pull_request_response.json && echo 200" \
+    "--silent --write-out '%{http_code}' --data '{\"reviewers\":[\"pr-reviewer\"],\"team_reviewers\":[]}' --header 'Authorization: Bearer secret-github-token' --output tmp/github_api_calls/request_reviews_response.json --request POST https://api.github.com/repos/owner/project/pulls/42/requested_reviewers : echo '{}' > tmp/github_api_calls/request_reviews_response.json && echo 200"
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
   stub buildkite-agent
 
   run $PWD/hooks/command
 
   assert_success
-  assert_output --partial 'Github pull request opened: pr-url'
+  assert_output --partial 'Github pull request opened: "https://github.com/owner/project/pull/42"'
   assert_output --partial 'Reviews requested'
   unstub curl
   unstub git
@@ -111,15 +112,15 @@ load "$BATS_PATH/load.bash"
   export GITHUB_TOKEN=secret-github-token
 
   stub curl \
-    '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200' \
-    '--silent --write-out %{http_code} --data json-request-reviews-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/request_reviews_response.json --request POST https://api.github.com/repos/owner/project/pulls/711/requested_reviewers : echo 200'
+    "--silent --write-out '%{http_code}' --data '{\"title\":\"pr-title\",\"body\":\"pr-body\",\"head\":\"feature-branch\",\"base\":\"master\"}' --header 'Authorization: Bearer secret-github-token' --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo '{\"number\":42,\"html_url\":\"https://github.com/owner/project/pull/42\"}' > tmp/github_api_calls/open_pull_request_response.json && echo 200" \
+    "--silent --write-out '%{http_code}' --data '{\"reviewers\":[\"pr-reviewer1\",\"pr-reviewer2\"],\"team_reviewers\":[]}' --header 'Authorization: Bearer secret-github-token' --output tmp/github_api_calls/request_reviews_response.json --request POST https://api.github.com/repos/owner/project/pulls/42/requested_reviewers : echo '{}' > tmp/github_api_calls/request_reviews_response.json && echo 200"
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
   stub buildkite-agent
 
   run $PWD/hooks/command
 
   assert_success
-  assert_output --partial 'Github pull request opened: pr-url'
+  assert_output --partial 'Github pull request opened: "https://github.com/owner/project/pull/42"'
   assert_output --partial 'Reviews requested'
   unstub curl
   unstub git
@@ -129,19 +130,19 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_BRANCH=feature-branch
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_TITLE=pr-title
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_BODY=pr-body
-  export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_TEAM_REVIEWERS=pr-reviewer
+  export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_TEAM_REVIEWERS=pr-reviewer-team
   export GITHUB_TOKEN=secret-github-token
 
   stub curl \
-    '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200' \
-    '--silent --write-out %{http_code} --data json-request-reviews-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/request_reviews_response.json --request POST https://api.github.com/repos/owner/project/pulls/711/requested_reviewers : echo 200'
+    "--silent --write-out '%{http_code}' --data '{\"title\":\"pr-title\",\"body\":\"pr-body\",\"head\":\"feature-branch\",\"base\":\"master\"}' --header 'Authorization: Bearer secret-github-token' --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo '{\"number\":42,\"html_url\":\"https://github.com/owner/project/pull/42\"}' > tmp/github_api_calls/open_pull_request_response.json && echo 200" \
+    "--silent --write-out '%{http_code}' --data '{\"reviewers\":[],\"team_reviewers\":[\"pr-reviewer-team\"]}' --header 'Authorization: Bearer secret-github-token' --output tmp/github_api_calls/request_reviews_response.json --request POST https://api.github.com/repos/owner/project/pulls/42/requested_reviewers : echo '{}' > tmp/github_api_calls/request_reviews_response.json && echo 200"
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
   stub buildkite-agent
 
   run $PWD/hooks/command
 
   assert_success
-  assert_output --partial 'Github pull request opened: pr-url'
+  assert_output --partial 'Github pull request opened: "https://github.com/owner/project/pull/42"'
   assert_output --partial 'Reviews requested'
   unstub curl
   unstub git
@@ -151,20 +152,20 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_BRANCH=feature-branch
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_TITLE=pr-title
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_BODY=pr-body
-  export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_TEAM_REVIEWERS_0=pr-reviewer1
-  export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_TEAM_REVIEWERS_1=pr-reviewer2
+  export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_TEAM_REVIEWERS_0=pr-reviewer-team1
+  export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_TEAM_REVIEWERS_1=pr-reviewer-team2
   export GITHUB_TOKEN=secret-github-token
 
   stub curl \
-    '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200' \
-    '--silent --write-out %{http_code} --data json-request-reviews-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/request_reviews_response.json --request POST https://api.github.com/repos/owner/project/pulls/711/requested_reviewers : echo 200'
+    "--silent --write-out '%{http_code}' --data '{\"title\":\"pr-title\",\"body\":\"pr-body\",\"head\":\"feature-branch\",\"base\":\"master\"}' --header 'Authorization: Bearer secret-github-token' --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo '{\"number\":42,\"html_url\":\"https://github.com/owner/project/pull/42\"}' > tmp/github_api_calls/open_pull_request_response.json && echo 200" \
+    "--silent --write-out '%{http_code}' --data '{\"reviewers\":[],\"team_reviewers\":[\"pr-reviewer-team1\",\"pr-reviewer-team2\"]}' --header 'Authorization: Bearer secret-github-token' --output tmp/github_api_calls/request_reviews_response.json --request POST https://api.github.com/repos/owner/project/pulls/42/requested_reviewers : echo '{}' > tmp/github_api_calls/request_reviews_response.json && echo 200"
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
   stub buildkite-agent
 
   run $PWD/hooks/command
 
   assert_success
-  assert_output --partial 'Github pull request opened: pr-url'
+  assert_output --partial 'Github pull request opened: "https://github.com/owner/project/pull/42"'
   assert_output --partial 'Reviews requested'
   unstub curl
   unstub git
@@ -178,15 +179,38 @@ load "$BATS_PATH/load.bash"
   export GITHUB_TOKEN=secret-github-token
 
   stub curl \
-    '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200' \
-    '--silent --write-out %{http_code} --data json-add-labels-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/add_labels_response.json --request POST https://api.github.com/repos/owner/project/issues/711/labels : echo 200'
+    "--silent --write-out '%{http_code}' --data '{\"title\":\"pr-title\",\"body\":\"pr-body\",\"head\":\"feature-branch\",\"base\":\"master\"}' --header 'Authorization: Bearer secret-github-token' --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo '{\"number\":42,\"html_url\":\"https://github.com/owner/project/pull/42\"}' > tmp/github_api_calls/open_pull_request_response.json && echo 200" \
+    "--silent --write-out '%{http_code}' --data '[\"pr-label\"]' --header 'Authorization: Bearer secret-github-token' --output tmp/github_api_calls/add_labels_response.json --request POST https://api.github.com/repos/owner/project/issues/42/labels : echo '{}' > tmp/github_api_calls/add_labels_response.json && echo 200"
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
   stub buildkite-agent
 
   run $PWD/hooks/command
 
   assert_success
-  assert_output --partial 'Github pull request opened: pr-url'
+  assert_output --partial 'Github pull request opened: "https://github.com/owner/project/pull/42"'
+  assert_output --partial 'Labels added'
+  unstub curl
+  unstub git
+}
+
+@test 'Opens the Github pull request and adds two labels' {
+  export BUILDKITE_BRANCH=feature-branch
+  export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_TITLE=pr-title
+  export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_BODY=pr-body
+  export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_LABELS_0=pr-label1
+  export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_LABELS_1=pr-label2
+  export GITHUB_TOKEN=secret-github-token
+
+  stub curl \
+    "--silent --write-out '%{http_code}' --data '{\"title\":\"pr-title\",\"body\":\"pr-body\",\"head\":\"feature-branch\",\"base\":\"master\"}' --header 'Authorization: Bearer secret-github-token' --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo '{\"number\":42,\"html_url\":\"https://github.com/owner/project/pull/42\"}' > tmp/github_api_calls/open_pull_request_response.json && echo 200" \
+    "--silent --write-out '%{http_code}' --data '[\"pr-label1\",\"pr-label2\"]' --header 'Authorization: Bearer secret-github-token' --output tmp/github_api_calls/add_labels_response.json --request POST https://api.github.com/repos/owner/project/issues/42/labels : echo '{}' > tmp/github_api_calls/add_labels_response.json && echo 200"
+  stub git 'remote get-url origin : echo "git@github.com:owner/project"'
+  stub buildkite-agent
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial 'Github pull request opened: "https://github.com/owner/project/pull/42"'
   assert_output --partial 'Labels added'
   unstub curl
   unstub git
@@ -198,15 +222,15 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_BODY=pr-body
   export GITHUB_TOKEN=secret-github-token
 
-  stub curl '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 500'
+  stub curl "--silent --write-out '%{http_code}' --data '{\"title\":\"pr-title\",\"body\":\"pr-body\",\"head\":\"feature-branch\",\"base\":\"master\"}' --header 'Authorization: Bearer secret-github-token' --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 'The error message from Github' > tmp/github_api_calls/open_pull_request_response.json && echo 512"
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
   stub buildkite-agent
 
   run $PWD/hooks/command
 
   assert_failure
-  assert_output --partial 'Github responded with 500:'
-  assert_output --partial 'json-open-pr-response'
+  assert_output --partial 'Github responded with 512:'
+  assert_output --partial 'error message from Github'
   unstub curl
   unstub git
 }

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load '/usr/local/lib/bats/load.bash'
+load "$BATS_PATH/load.bash"
 
 # Uncomment the following to get more detail on failures of stubs
 # export JQ_STUB_DEBUG=/dev/tty

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -3,7 +3,6 @@
 load "$BATS_PATH/load.bash"
 
 # Uncomment the following to get more detail on failures of stubs
-# export JQ_STUB_DEBUG=/dev/tty
 # export CURL_STUB_DEBUG=/dev/tty
 # export GIT_STUB_DEBUG=/dev/tty
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
@@ -14,10 +13,6 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_BODY=pr-body
   export GITHUB_TOKEN=secret-github-token
 
-  stub jq \
-    '-n --arg TITLE pr-title --arg BODY pr-body --arg HEAD feature-branch --arg BASE master "{ title: $TITLE, body: $BODY, head: $HEAD, base: $BASE }" : echo json-open-pr-request' \
-    '.number : echo 711' \
-    '.html_url : echo pr-url'
   stub curl '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200'
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
   stub buildkite-agent
@@ -26,7 +21,6 @@ load "$BATS_PATH/load.bash"
 
   assert_success
   assert_output --partial 'Github pull request opened: pr-url'
-  unstub jq
   unstub curl
   unstub git
 }
@@ -37,10 +31,6 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_BODY=pr-body
   export GITHUB_TOKEN=secret-github-token
 
-  stub jq \
-    '-n --arg TITLE pr-title --arg BODY pr-body --arg HEAD feature-branch --arg BASE master "{ title: $TITLE, body: $BODY, head: $HEAD, base: $BASE }" : echo json-open-pr-request' \
-    '.number : echo 711' \
-    '.html_url : echo pr-url'
   stub curl '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200'
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
   stub buildkite-agent 'meta-data set github-pull-request-plugin-number 711 : echo metadata set'
@@ -58,10 +48,6 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_REPO=another-owner/another-project
   export GITHUB_TOKEN=secret-github-token
 
-  stub jq \
-    '-n --arg TITLE pr-title --arg BODY pr-body --arg HEAD feature-branch --arg BASE master "{ title: $TITLE, body: $BODY, head: $HEAD, base: $BASE }" : echo json-open-pr-request' \
-    '.number : echo 711' \
-    '.html_url : echo pr-url'
   stub curl '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/another-owner/another-project/pulls : echo 200'
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
   stub buildkite-agent
@@ -70,7 +56,6 @@ load "$BATS_PATH/load.bash"
 
   assert_success
   assert_output --partial 'Github pull request opened: pr-url'
-  unstub jq
   unstub curl
   unstub git
 }
@@ -83,10 +68,6 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_BASE=pr-base
   export GITHUB_TOKEN=secret-github-token
 
-  stub jq \
-    '-n --arg TITLE pr-title --arg BODY pr-body --arg HEAD pr-head --arg BASE pr-base "{ title: $TITLE, body: $BODY, head: $HEAD, base: $BASE }" : echo json-open-pr-request' \
-    '.number : echo 711' \
-    '.html_url : echo pr-url'
   stub curl '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200'
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
   stub buildkite-agent
@@ -95,7 +76,6 @@ load "$BATS_PATH/load.bash"
 
   assert_success
   assert_output --partial 'Github pull request opened: pr-url'
-  unstub jq
   unstub curl
   unstub git
 }
@@ -107,11 +87,6 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_REVIEWERS=pr-reviewer
   export GITHUB_TOKEN=secret-github-token
 
-  stub jq \
-    '-n --arg TITLE pr-title --arg BODY pr-body --arg HEAD feature-branch --arg BASE master "{ title: $TITLE, body: $BODY, head: $HEAD, base: $BASE }" : echo json-open-pr-request' \
-    '.number : echo 711' \
-    '.html_url : echo pr-url' \
-    '-n --arg REVIEWERS "pr-reviewer" --arg TEAM_REVIEWERS "" "{ reviewers: $REVIEWERS | split(\"\n\"), team_reviewers: $TEAM_REVIEWERS | split(\"\n\") }" : echo json-request-reviews-request'
   stub curl \
     '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200' \
     '--silent --write-out %{http_code} --data json-request-reviews-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/request_reviews_response.json --request POST https://api.github.com/repos/owner/project/pulls/711/requested_reviewers : echo 200'
@@ -123,7 +98,6 @@ load "$BATS_PATH/load.bash"
   assert_success
   assert_output --partial 'Github pull request opened: pr-url'
   assert_output --partial 'Reviews requested'
-  unstub jq
   unstub curl
   unstub git
 }
@@ -136,11 +110,6 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_REVIEWERS_1=pr-reviewer2
   export GITHUB_TOKEN=secret-github-token
 
-  stub jq \
-    '-n --arg TITLE pr-title --arg BODY pr-body --arg HEAD feature-branch --arg BASE master "{ title: $TITLE, body: $BODY, head: $HEAD, base: $BASE }" : echo json-open-pr-request' \
-    '.number : echo 711' \
-    '.html_url : echo pr-url' \
-    '-n --arg REVIEWERS "pr-reviewer1\npr-reviewer2" --arg TEAM_REVIEWERS "" "{ reviewers: $REVIEWERS | split(\"\n\"), team_reviewers: $TEAM_REVIEWERS | split(\"\n\") }" : echo json-request-reviews-request'
   stub curl \
     '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200' \
     '--silent --write-out %{http_code} --data json-request-reviews-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/request_reviews_response.json --request POST https://api.github.com/repos/owner/project/pulls/711/requested_reviewers : echo 200'
@@ -152,7 +121,6 @@ load "$BATS_PATH/load.bash"
   assert_success
   assert_output --partial 'Github pull request opened: pr-url'
   assert_output --partial 'Reviews requested'
-  unstub jq
   unstub curl
   unstub git
 }
@@ -164,11 +132,6 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_TEAM_REVIEWERS=pr-reviewer
   export GITHUB_TOKEN=secret-github-token
 
-  stub jq \
-    '-n --arg TITLE pr-title --arg BODY pr-body --arg HEAD feature-branch --arg BASE master "{ title: $TITLE, body: $BODY, head: $HEAD, base: $BASE }" : echo json-open-pr-request' \
-    '.number : echo 711' \
-    '.html_url : echo pr-url' \
-    '-n --arg REVIEWERS "" --arg TEAM_REVIEWERS "pr-reviewer" "{ reviewers: $REVIEWERS | split(\"\n\"), team_reviewers: $TEAM_REVIEWERS | split(\"\n\") }" : echo json-request-reviews-request'
   stub curl \
     '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200' \
     '--silent --write-out %{http_code} --data json-request-reviews-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/request_reviews_response.json --request POST https://api.github.com/repos/owner/project/pulls/711/requested_reviewers : echo 200'
@@ -180,7 +143,6 @@ load "$BATS_PATH/load.bash"
   assert_success
   assert_output --partial 'Github pull request opened: pr-url'
   assert_output --partial 'Reviews requested'
-  unstub jq
   unstub curl
   unstub git
 }
@@ -193,11 +155,6 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_TEAM_REVIEWERS_1=pr-reviewer2
   export GITHUB_TOKEN=secret-github-token
 
-  stub jq \
-    '-n --arg TITLE pr-title --arg BODY pr-body --arg HEAD feature-branch --arg BASE master "{ title: $TITLE, body: $BODY, head: $HEAD, base: $BASE }" : echo json-open-pr-request' \
-    '.number : echo 711' \
-    '.html_url : echo pr-url' \
-    '-n --arg REVIEWERS "" --arg TEAM_REVIEWERS "pr-reviewer1\npr-reviewer2" "{ reviewers: $REVIEWERS | split(\"\n\"), team_reviewers: $TEAM_REVIEWERS | split(\"\n\") }" : echo json-request-reviews-request'
   stub curl \
     '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200' \
     '--silent --write-out %{http_code} --data json-request-reviews-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/request_reviews_response.json --request POST https://api.github.com/repos/owner/project/pulls/711/requested_reviewers : echo 200'
@@ -209,7 +166,6 @@ load "$BATS_PATH/load.bash"
   assert_success
   assert_output --partial 'Github pull request opened: pr-url'
   assert_output --partial 'Reviews requested'
-  unstub jq
   unstub curl
   unstub git
 }
@@ -221,11 +177,6 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_LABELS=pr-label
   export GITHUB_TOKEN=secret-github-token
 
-  stub jq \
-    '-n --arg TITLE pr-title --arg BODY pr-body --arg HEAD feature-branch --arg BASE master "{ title: $TITLE, body: $BODY, head: $HEAD, base: $BASE }" : echo json-open-pr-request' \
-    '.number : echo 711' \
-    '.html_url : echo pr-url' \
-    '-n --arg LABELS "pr-label" "$LABELS | split(\"\n\")" : echo json-add-labels-request'
   stub curl \
     '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 200' \
     '--silent --write-out %{http_code} --data json-add-labels-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/add_labels_response.json --request POST https://api.github.com/repos/owner/project/issues/711/labels : echo 200'
@@ -237,7 +188,6 @@ load "$BATS_PATH/load.bash"
   assert_success
   assert_output --partial 'Github pull request opened: pr-url'
   assert_output --partial 'Labels added'
-  unstub jq
   unstub curl
   unstub git
 }
@@ -248,10 +198,6 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_GITHUB_PULL_REQUEST_BODY=pr-body
   export GITHUB_TOKEN=secret-github-token
 
-  stub jq \
-    '-n --arg TITLE pr-title --arg BODY pr-body --arg HEAD feature-branch --arg BASE master "{ title: $TITLE, body: $BODY, head: $HEAD, base: $BASE }" : echo json-open-pr-request' \
-    '.number : echo 711' \
-    '.html_url : echo pr-url'
   stub curl '--silent --write-out %{http_code} --data json-open-pr-request --header "Authorization: Bearer secret-github-token" --output tmp/github_api_calls/open_pull_request_response.json --request POST https://api.github.com/repos/owner/project/pulls : echo 500'
   stub git 'remote get-url origin : echo "git@github.com:owner/project"'
   stub buildkite-agent


### PR DESCRIPTION
Rather than stubbing `cat` and `jq`, let them run through and assert on interactions with Github by inspecting the the arguments provided to cURL.

This involves installing `jq` on the Docker container we're using for testing.

Additionally, produce compact JSON for API requests to Github: it's easier to assert on content without new line characters.